### PR TITLE
Removing a fastercsv reference for Ruby 1.9 support

### DIFF
--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -211,7 +211,7 @@ module Ruport::Data
       private
       
       def get_table_from_csv(msg,param,options={},&block) #:nodoc:
-        require "fastercsv"
+        require "fastercsv" unless RUBY_VERSION > "1.9"
 
         options = {:has_names => true,
                    :csv_options => {} }.merge(options)


### PR DESCRIPTION
There is a single "require 'fastercsv'" that causes problems in my particular environment (in Ruby 1.9).

The ideal thing to do here would be to remove the require altogether.  However, I'm not sure why it is there, and what issues it was intended to solve.  If that is a better solution, then please reject this pull request and delete the line.
