### PR TITLE
Don't depend on fastercsv for ruby 1.9.

### DIFF
--- a/ruport.gemspec
+++ b/ruport.gemspec
@@ -152,14 +152,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<fastercsv>, [">= 0"])
+      s.add_runtime_dependency(%q<fastercsv>, [">= 0"]) if RUBY_VERSION < "1.9"
       s.add_runtime_dependency(%q<pdf-writer>, ["= 1.1.8"])
     else
-      s.add_dependency(%q<fastercsv>, [">= 0"])
+      s.add_dependency(%q<fastercsv>, [">= 0"]) if RUBY_VERSION < "1.9"
       s.add_dependency(%q<pdf-writer>, ["= 1.1.8"])
     end
   else
-    s.add_dependency(%q<fastercsv>, [">= 0"])
+    s.add_dependency(%q<fastercsv>, [">= 0"]) if RUBY_VERSION < "1.9"
     s.add_dependency(%q<pdf-writer>, ["= 1.1.8"])
   end
 end


### PR DESCRIPTION
Also, can you release an official version of 1.7.0 since 1.6.3 is the latest on rubygems.org but there have been many important changes since then.

Thanks!
