### PR TITLE
Avoid division by zero in Operations::mean. 

### DIFF
--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -132,6 +132,7 @@ module Ruport::Data
         end
 
         def mean(rows, summary_column)
+          return if rows.length == 0
           sum = rows && rows.inject(0) { |sum,row| sum+row[summary_column] }
           sum / rows.length
         end

--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -47,7 +47,7 @@ module Ruport::Data
         ordering = self.class.row_order_to_group_order(@pivot_order)
         pivot_column_grouping.sort_grouping_by!(ordering) if ordering
 
-        @row = pivot_column_grouping.map { |grouping| grouping[0] }
+        @row = pivot_column_grouping.map { |name,grouping| name }
       end
 
       # Column in the first column in the pivoted table (without the group column)


### PR DESCRIPTION
I get division by zero in some of my pivot tables. 

This is just a simple check that returns nil if we risk a division by zero.
