### PR TITLE
Do not restrict Rake version

### DIFF
--- a/ruport.gemspec
+++ b/ruport.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency(%q<prawn>, ["= 0.12.0"])
   end
 
-  s.add_development_dependency(%q<rake>, [">= 0.8.7"])
+  s.add_development_dependency(%q<rake>)
 end


### PR DESCRIPTION
This was causing me some grief:

```
Fetching gem metadata from http://rubygems.org/......
Fetching gem metadata from http://rubygems.org/..
Bundler could not find compatible versions for gem "rake":
  In Gemfile:
    ruport (= 1.6.3) ruby depends on
      rake (~> 0.8) ruby

    rails (~> 3.1.7) ruby depends on
      rake (10.0.3)
```
