### PR TITLE
Fix Ruport#Table method so it is class-level

### DIFF
--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -1040,7 +1040,7 @@ module Ruport
   #
   #   t = Table("foo.csv")
   #   t = Table("bar.csv", :has_names => false)
-  def Table(*args,&block)
+  def self.Table(*args,&block)
     case(args[0])
     when Array
       opts = args[1] || {}


### PR DESCRIPTION
In Ruport v1.6.3, `Ruport::Data#Table` is a class-level method.  In the current source it is an instant-level method, which caused my project to break (because we were invoking the class-level method) when I updated.

I believe that this got broken in 86f439fc when @Odaeus rightfully moved the location of the method from `Kernel` to `Ruport`, but didn't remember to set it as a class-level method.