### PR TITLE
Add Ruby dotfiles (.ruby-version/gemset) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ doc/
 pkg/
 *.pdf
 Gemfile.lock
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
Ruby dotfiles are common practice for seamlessly working on multiple projects.

They make life much more... automated, without impacting the project, as they are in the .gitignore.