### PR TITLE
Improve compatibility with Ruby 2.4

### DIFF
--- a/lib/ruport/data/record.rb
+++ b/lib/ruport/data/record.rb
@@ -140,7 +140,7 @@ module Ruport::Data
       case name
       when String,Symbol
         self[name] || send(name)
-      when Fixnum
+      when Integer
         self[name]
       else
         raise ArgumentError, "Whatchu Talkin' Bout, Willis?"

--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -576,7 +576,7 @@ module Ruport::Data
     #    table.remove_column("apple") #=> removes column named apple
     #
     def remove_column(col)
-      col = column_names[col] if col.kind_of? Fixnum
+      col = column_names[col] if col.kind_of? Integer
       column_names.delete(col)
       each { |r| r.send(:delete,col) }
     end
@@ -666,7 +666,7 @@ module Ruport::Data
     #       +-----------+
     #
     def swap_column(a,b)
-      if [a,b].all? { |r| r.kind_of? Fixnum }
+      if [a,b].all? { |r| r.kind_of? Integer }
        col_a,col_b = column_names[a],column_names[b]
        column_names[a] = col_b
        column_names[b] = col_a

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -63,11 +63,10 @@ class TestTable < Minitest::Test
     end
 
     def specify_transforms_should_modify_table_data
-
      stringify_c = lambda { |r| r.c = r.c.to_s }
      add_two_to_all_int_cols = lambda { |r|
       r.each_with_index do |c,i|
-        if Fixnum === c
+        if Integer === c
           r[i] += 2
         end
       end


### PR DESCRIPTION
Ruby 2.4 deprecates the Fixnum and Bignum classes, since it merged them into a single class - Integer.

Since Integer has always been the superclass of Fixnum and Bignum, it's possible to replace all the class tests from Fixnum (/Bignum) to Integer, and still retain backwards compatibility.