### PR TITLE
Clean and repair test suite

### DIFF
--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -w   
+#!/usr/bin/env ruby -w
 require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 ###########################################################################
@@ -28,7 +28,7 @@ class OldSchoolController < Ruport::Controller
     end
   end
 
-end               
+end
 
 class VanillaController < Ruport::Controller
   stage :header,:body,:footer
@@ -39,9 +39,9 @@ end
 # that the hooks are being set up right.  Perhaps these could
 # be replaced by mock objects in the future.
 class DummyText < Ruport::Formatter
-  
+
   renders :text, :for => OldSchoolController
-  
+
   def prepare_document
     output << "p"
   end
@@ -61,7 +61,7 @@ class DummyText < Ruport::Formatter
   def finalize_document
     output << "f"
   end
-end   
+end
 
 # This formatter modifies the (String) data object passed to it
 class Destructive < Ruport::Formatter
@@ -84,11 +84,11 @@ end
 class VanillaBinary < Ruport::Formatter
   renders :bin, :for => VanillaController
   save_as_binary_file
-end 
+end
 
 class SpecialFinalize < Ruport::Formatter
   renders :with_finalize, :for => VanillaController
-  
+
   def finalize
     output << "I has been finalized"
   end
@@ -103,27 +103,27 @@ class TestController < Minitest::Test
   def test_trivial
     actual = OldSchoolController.render(:text)
     assert_equal "header\nbody\nfooter\n", actual
-  end          
-  
+  end
+
   context "when running a formatter with custom a finalize method" do
     def specify_finalize_method_should_be_called
-      assert_equal "I has been finalized", 
+      assert_equal "I has been finalized",
                    VanillaController.render_with_finalize
-    end                
+    end
   end
-  
+
   context "when using templates" do
     def specify_apply_template_should_be_called
       Ruport::Formatter::Template.create(:stub)
       Ruport.Table(%w[a b c]).to_csv(:template => :stub) do |r|
        r.formatter.expects(:apply_template)
-      end  
-    end 
+      end
+    end
 
     def specify_undefined_template_should_throw_sensible_error
       assert_raises(Ruport::Formatter::TemplateNotDefined) do
         Ruport.Table(%w[a b c]).to_csv(:template => :sub)
-      end 
+      end
     end
   end
 
@@ -133,7 +133,7 @@ class TestController < Minitest::Test
       Ruport.Table(%w[a b c]).to_csv do |r|
         r.formatter.expects(:apply_template)
         assert r.formatter.template == Ruport::Formatter::Template[:default]
-      end  
+      end
     end
 
     def specify_specific_should_override_default
@@ -142,14 +142,14 @@ class TestController < Minitest::Test
       Ruport.Table(%w[a b c]).to_csv(:template => :stub) do |r|
         r.formatter.expects(:apply_template)
         assert r.formatter.template == Ruport::Formatter::Template[:stub]
-      end  
+      end
     end
 
     def specify_should_be_able_to_disable_templates
       Ruport::Formatter::Template.create(:default)
       Ruport.Table(%w[a b c]).to_csv(:template => false) do |r|
         r.formatter.expects(:apply_template).never
-      end  
+      end
     end
   end
 
@@ -167,19 +167,19 @@ class TestController < Minitest::Test
     File.expects(:open).yields(f)
     a = OldSchoolController.render(:text, :file => "foo.text")
     assert_equal "header\nbody\nfooter\n", f[0]
-    
+
     f = []
     File.expects(:open).with("blah","wb").yields(f)
-    VanillaController.render(:bin, :file => "blah")        
-  end       
-  
-  def test_using_file_via_rendering_tools     
-    f = []
-    File.expects(:open).yields(f)  
-    Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]]).save_as("foo.csv")
-    assert_equal "a,b,c\n1,2,3\n4,5,6\n", f[0]  
+    VanillaController.render(:bin, :file => "blah")
   end
-    
+
+  def test_using_file_via_rendering_tools
+    f = []
+    File.expects(:open).yields(f)
+    Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]]).save_as("foo.csv")
+    assert_equal "a,b,c\n1,2,3\n4,5,6\n", f[0]
+  end
+
 
   def test_formats
     assert_equal( {}, Ruport::Controller.formats )
@@ -209,33 +209,33 @@ class TestController < Minitest::Test
 
     rend.formatter.clear_output
     assert_equal "", rend.formatter.output
-  end  
-  
+  end
+
   def test_options_act_like_indifferent_hash
      opts = Ruport::Controller::Options.new
      opts.foo = "bar"
      assert_equal "bar", opts[:foo]
-     assert_equal "bar", opts["foo"]    
-     
+     assert_equal "bar", opts["foo"]
+
      opts["f"] = "bar"
      assert_equal "bar", opts[:f]
      assert_equal "bar", opts.f
      assert_equal "bar", opts["f"]
-     
+
      opts[:apple] = "banana"
      assert_equal "banana", opts.apple
      assert_equal "banana", opts["apple"]
      assert_equal "banana", opts[:apple]
-  end     
-  
+  end
+
 end
 
 
 class TestFormatterUsingBuild < Minitest::Test
   # This formatter uses the build syntax
   class UsesBuild < Ruport::Formatter
-     renders :text_using_build, :for => VanillaController 
-     
+     renders :text_using_build, :for => VanillaController
+
      build :header do
        output << "header\n"
      end
@@ -246,7 +246,7 @@ class TestFormatterUsingBuild < Minitest::Test
 
      build :footer do
        output << "footer\n"
-     end     
+     end
   end
 
   def test_should_render_using_build_syntax
@@ -265,21 +265,21 @@ class TestFormatterWithLayout < Minitest::Test
   # This formatter is meant to check out a special case in Ruport's renderer,
   # in which a layout method is called and yielded to when defined
   class WithLayout < DummyText
-     renders :text_with_layout, :for => VanillaController 
-     
-     def layout     
+     renders :text_with_layout, :for => VanillaController
+
+     def layout
        output << "---\n"
        yield
        output << "---\n"
      end
-     
+
   end
 
   def test_layout
-     assert_equal "---\nheader\nbody\nfooter\n---\n", 
+     assert_equal "---\nheader\nbody\nfooter\n---\n",
                   VanillaController.render_text_with_layout
   end
-  
+
   def test_layout_disabled
      assert_equal "header\nbody\nfooter\n",
                   VanillaController.render_text_with_layout(:layout => false)
@@ -320,11 +320,11 @@ class TestControllerWithManyHooks < Minitest::Test
    a = ControllerWithManyHooks.render(:text, :data => [1,2,4]) { |r|
      assert_equal [1,2,4], r.data
    }
-  
+
    b = ControllerWithManyHooks.render_text(%w[a b c]) { |r|
      assert_equal %w[a b c], r.data
    }
-  
+
    c = ControllerWithManyHooks.render_text(%w[a b f],:snapper => :red) { |r|
      assert_equal %w[a b f], r.data
      assert_equal :red, r.options.snapper
@@ -341,7 +341,7 @@ class TestControllerWithManyHooks < Minitest::Test
   def test_stage_helper
     assert ControllerWithManyHooks.stages.include?('body')
   end
- 
+
   def test_finalize_helper
     assert_equal :document, ControllerWithManyHooks.final_stage
   end
@@ -351,14 +351,14 @@ class TestControllerWithManyHooks < Minitest::Test
   end
 
   def test_finalize_again
-   assert_raises(Ruport::Controller::StageAlreadyDefinedError) { 
-     ControllerWithManyHooks.finalize :report 
+   assert_raises(Ruport::Controller::StageAlreadyDefinedError) {
+     ControllerWithManyHooks.finalize :report
    }
   end
 
   def test_prepare_again
-   assert_raises(Ruport::Controller::StageAlreadyDefinedError) { 
-     ControllerWithManyHooks.prepare :foo 
+   assert_raises(Ruport::Controller::StageAlreadyDefinedError) {
+     ControllerWithManyHooks.prepare :foo
    }
   end
 
@@ -387,7 +387,7 @@ class TestControllerWithManyHooks < Minitest::Test
 
    assert_raises(Ruport::Controller::RequiredOptionNotSet) { a.render(:text) }
   end
- 
+
 end
 
 
@@ -409,7 +409,7 @@ class TestControllerWithRunHook < Minitest::Test
   end
 
   def test_renderer_with_run_hooks
-    assert_equal "|header\nbody\nfooter\n", 
+    assert_equal "|header\nbody\nfooter\n",
        ControllerWithRunHook.render_text(:foo => "bar",:bar => "baz")
   end
 
@@ -427,7 +427,7 @@ class TestControllerWithHelperModule < Minitest::Test
         "Hello Dolly"
       end
     end
-  end   
+  end
 
   def test_renderer_helper_module
     ControllerWithHelperModule.render_stub do |r|
@@ -439,7 +439,7 @@ end
 
 class TestMultiPurposeFormatter < Minitest::Test
   # This provides a way to check the multi-format hooks for the Controller
-  class MultiPurposeFormatter < Ruport::Formatter 
+  class MultiPurposeFormatter < Ruport::Formatter
 
      renders [:html,:text], :for => VanillaController
 
@@ -447,7 +447,7 @@ class TestMultiPurposeFormatter < Minitest::Test
        a = 10
 
        text { output << "Foo: #{a}\n" }
-       html { output << "<b>Foo: #{a}</b>\n" } 
+       html { output << "<b>Foo: #{a}</b>\n" }
      end
 
      def build_body
@@ -456,7 +456,7 @@ class TestMultiPurposeFormatter < Minitest::Test
        html { output << "\n</pre>\n" }
      end
 
-  end   
+  end
 
   def test_multi_purpose
     text = VanillaController.render_text(:body_text => "foo")
@@ -471,12 +471,12 @@ class TestMultiPurposeFormatter < Minitest::Test
 
     a = MultiPurposeFormatter.new
     a.format = :html
-    
+
     visited = false
     a.html { visited = true }
 
     assert visited
-    
+
     visited = false
     a.text { visited = true }
     assert !visited
@@ -504,7 +504,7 @@ class TestFormatterErbHelper < Minitest::Test
          output << erb("Default Binding: <%= @foo %>")
        end
     end
-    
+
   end
 
   #FIXME: need to test file
@@ -523,66 +523,66 @@ end
 
 
 class TestOptionReaders < Minitest::Test
-  
+
   class ControllerForCheckingOptionReaders < Ruport::Controller
-    required_option :foo  
-  end 
-  
+    required_option :foo
+  end
+
   class ControllerForCheckingPassivity < Ruport::Controller
     def foo
       "apples"
     end
-    required_option :foo    
+    required_option :foo
   end
 
-   def setup 
-     @renderer = ControllerForCheckingOptionReaders.new 
-     @renderer.formatter = Ruport::Formatter.new 
-     
+   def setup
+     @renderer = ControllerForCheckingOptionReaders.new
+     @renderer.formatter = Ruport::Formatter.new
+
      @passive = ControllerForCheckingPassivity.new
      @passive.formatter = Ruport::Formatter.new
    end
-   
+
    def test_options_are_readable
       @renderer.foo = 5
       assert_equal 5, @renderer.foo
-   end                                   
-   
+   end
+
    def test_methods_are_not_overridden
      @passive.foo = 5
      assert_equal "apples", @passive.foo
      assert_equal 5, @passive.options.foo
      assert_equal 5, @passive.formatter.options.foo
    end
-     
+
 end
-     
+
 class TestSetupOrdering < Minitest::Test
-   
+
   class ControllerWithSetup < Ruport::Controller
     stage :bar
     def setup
       options.foo.capitalize!
-    end        
-  end           
-  
-  class BasicFormatter < Ruport::Formatter 
+    end
+  end
+
+  class BasicFormatter < Ruport::Formatter
     renders :text, :for => ControllerWithSetup
-    
+
     def build_bar
       output << options.foo
     end
   end
-  
+
   def test_render_hash_options_should_be_called_before_setup
     assert_equal "Hello", ControllerWithSetup.render_text(:foo => "hello")
-  end       
-  
+  end
+
   def test_render_block_should_be_called_before_setup
-    assert_equal "Hello", 
+    assert_equal "Hello",
       ControllerWithSetup.render_text { |r| r.options.foo = "hello" }
   end
-  
+
 end
 
 class CustomFormatter < Ruport::Formatter
@@ -608,7 +608,7 @@ class ControllerWithAnonymousFormatters < Ruport::Controller
   end
 
   formatter :pdf do
-    build :report do 
+    build :report do
       add_text "hello world"
     end
   end
@@ -673,7 +673,7 @@ class TestControllerHooks < Minitest::Test
 
   require "mocha"
 
-  class DummyObject 
+  class DummyObject
     include Ruport::Controller::Hooks
     renders_as_table
   end
@@ -706,7 +706,7 @@ class TestControllerHooks < Minitest::Test
   class DummyObject3
     include Ruport::Controller::Hooks
     renders_as_table
-    
+
     def renderable_data
       raise ArgumentError
     end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -106,21 +106,21 @@ class TestController < Minitest::Test
   end
 
   context "when running a formatter with custom a finalize method" do
-    def specify_finalize_method_should_be_called
+    should "specify_finalize_method_should_be_called" do
       assert_equal "I has been finalized",
                    VanillaController.render_with_finalize
     end
   end
 
   context "when using templates" do
-    def specify_apply_template_should_be_called
+    should "specify_apply_template_should_be_called" do
       Ruport::Formatter::Template.create(:stub)
       Ruport.Table(%w[a b c]).to_csv(:template => :stub) do |r|
        r.formatter.expects(:apply_template)
       end
     end
 
-    def specify_undefined_template_should_throw_sensible_error
+    should "specify_undefined_template_should_throw_sensible_error" do
       assert_raises(Ruport::Formatter::TemplateNotDefined) do
         Ruport.Table(%w[a b c]).to_csv(:template => :sub)
       end
@@ -128,7 +128,7 @@ class TestController < Minitest::Test
   end
 
   context "when using default templates" do
-    def specify_default_template_should_be_called
+    should "specify_default_template_should_be_called" do
       Ruport::Formatter::Template.create(:default)
       Ruport.Table(%w[a b c]).to_csv do |r|
         r.formatter.expects(:apply_template)
@@ -136,7 +136,7 @@ class TestController < Minitest::Test
       end
     end
 
-    def specify_specific_should_override_default
+    should "specify_specific_should_override_default" do
       Ruport::Formatter::Template.create(:default)
       Ruport::Formatter::Template.create(:stub)
       Ruport.Table(%w[a b c]).to_csv(:template => :stub) do |r|
@@ -145,7 +145,7 @@ class TestController < Minitest::Test
       end
     end
 
-    def specify_should_be_able_to_disable_templates
+    should "specify_should_be_able_to_disable_templates" do
       Ruport::Formatter::Template.create(:default)
       Ruport.Table(%w[a b c]).to_csv(:template => false) do |r|
         r.formatter.expects(:apply_template).never

--- a/test/csv_formatter_test.rb
+++ b/test/csv_formatter_test.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -w   
+#!/usr/bin/env ruby -w
 require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class TestRenderCSVRow < Minitest::Test
@@ -9,7 +9,7 @@ class TestRenderCSVRow < Minitest::Test
 end
 
 class TestRenderCSVTable < Minitest::Test
-  
+
   def setup
     Ruport::Formatter::Template.create(:simple) do |format|
       format.table = {
@@ -24,7 +24,7 @@ class TestRenderCSVTable < Minitest::Test
   end
 
   def test_render_csv_table
-    actual = Ruport::Controller::Table.render_csv do |r| 
+    actual = Ruport::Controller::Table.render_csv do |r|
       r.data = Ruport.Table([], :data => [[1,2,3],[4,5,6]])
     end
     assert_equal("1,2,3\n4,5,6\n",actual)
@@ -33,32 +33,32 @@ class TestRenderCSVTable < Minitest::Test
       r.data = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
     end
     assert_equal("a,b,c\n1,2,3\n4,5,6\n",actual)
-  end   
-  
+  end
+
   def test_format_options
     a = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
-    assert_equal "a\tb\tc\n1\t2\t3\n4\t5\t6\n", 
+    assert_equal "a\tb\tc\n1\t2\t3\n4\t5\t6\n",
       a.as(:csv,:format_options => { :col_sep => "\t" })
   end
 
   def test_table_headers
     actual = Ruport::Controller::Table.
-             render_csv(:show_table_headers => false, 
+             render_csv(:show_table_headers => false,
                         :data => Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]]))
     assert_equal("1,2,3\n4,5,6\n",actual)
   end
-     
+
   def test_render_with_template
     formatter = Ruport::Formatter::CSV.new
     formatter.options = Ruport::Controller::Options.new
     formatter.options.template = :simple
     formatter.apply_template
-    
+
     assert_equal false, formatter.options.show_table_headers
 
     assert_equal :justified, formatter.options.style
     assert_equal false, formatter.options.show_group_headers
-    
+
     assert_equal ":", formatter.options.format_options[:col_sep]
   end
 
@@ -77,7 +77,7 @@ class TestRenderCSVTable < Minitest::Test
     ) do |r|
       opts = r.options
     end
-    
+
     assert_equal true, opts.show_table_headers
 
     assert_equal :raw, opts.style
@@ -96,15 +96,15 @@ class TestRenderCSVTable < Minitest::Test
     ) do |r|
       opts = r.options
     end
-    
+
     assert_equal true, opts.show_table_headers
 
     assert_equal :raw, opts.style
     assert_equal true, opts.show_group_headers
-    
+
     assert_equal ";", opts.format_options[:col_sep]
   end
-end     
+end
 
 class TestRenderCSVGroup < Minitest::Test
 
@@ -115,8 +115,8 @@ class TestRenderCSVGroup < Minitest::Test
     actual = Ruport::Controller::Group.
              render_csv(:data => group, :show_table_headers => false )
     assert_equal("test\n\n1,2,3\n4,5,6\n",actual)
-  end 
-  
+  end
+
 end
 
 class RenderCSVGrouping < Minitest::Test
@@ -138,25 +138,25 @@ class RenderCSVGrouping < Minitest::Test
     actual = grouping.to_csv :show_table_headers => false
 
     assert_equal "is\n\nthis,annoying\nit,funny\n\n", actual
-  end  
+  end
 
   def test_alternative_styles
     g = Grouping((Ruport.Table(%w[a b c]) << [1,2,3] << [1,1,4] <<
                                       [2,1,2] << [1,9,1] ), :by => "a")
-    
+
     assert_raises(NotImplementedError) { g.to_csv :style => :not_real }
 
-    assert_equal "a,b,c\n1,2,3\n,1,4\n,9,1\n\n2,1,2\n\n", 
+    assert_equal "a,b,c\n1,2,3\n,1,4\n,9,1\n\n2,1,2\n\n",
                  g.to_csv(:style => :justified)
 
     assert_equal "a,b,c\n1,2,3\n1,1,4\n1,9,1\n\n2,1,2\n\n",
-                  g.to_csv(:style => :raw) 
+                  g.to_csv(:style => :raw)
   end
 
   # -----------------------------------------------------------------------
   # BUG TRAPS
   # ------------------------------------------------------------------------
-  
+
   def test_ensure_group_names_are_converted_to_string
     g = Grouping((Ruport.Table(%w[a b c])<<[1,2,3]<<[1,1,4]), :by => "a")
     assert_equal "1\n\nb,c\n2,3\n1,4\n\n", g.to_csv

--- a/test/data_feeder_test.rb
+++ b/test/data_feeder_test.rb
@@ -1,88 +1,88 @@
-#!/usr/bin/env ruby -w   
-require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")    
+#!/usr/bin/env ruby -w
+require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class DataFeederTest < Minitest::Test
-   
+
   context "when using a default data feeder" do
-      
+
     setup do
       @feeder = Ruport::Data::Feeder.new(Ruport.Table(%w[a b c]))
-    end    
-    
+    end
+
     should "data attribute should return wrapped data" do
       assert_equal Ruport.Table(%w[a b c]), @feeder.data
     end
-     
+
     should "append should forward to wrapped data by default" do
       t = Ruport.Table(%w[a b c])
       t << [1,2,3] << {"a" => 2, "b" => 3, "c" => 4}
-      @feeder << [1,2,3] << {"a" => 2, "b" => 3, "c" => 4} 
-      assert_equal t, @feeder.data 
-    end  
-    
-  end 
-  
+      @feeder << [1,2,3] << {"a" => 2, "b" => 3, "c" => 4}
+      assert_equal t, @feeder.data
+    end
+
+  end
+
   context "when using a feeder with a filter" do
-     setup do 
+     setup do
        @feeder = Ruport::Data::Feeder.new(Ruport.Table(%w[a b c]))
        @feeder.filter { |r| r.a != 1 }
-     end    
-     
+     end
+
      should "filter should only append rows for which block is true" do
        @feeder << [1,2,3] << [4,1,2] << [3,1,1] << [1,2,5]
        assert_equal Ruport.Table(%w[a b c], :data => [[4,1,2],[3,1,1]]), @feeder.data
      end
-  end 
-  
+  end
+
   context "when using a feeder with a transform" do
      setup do
        @feeder = Ruport::Data::Feeder.new(Ruport.Table(%w[a b c]))
        @feeder.transform { |r| r.a += 1 }
      end
-     
+
      should "filter should be applied to all rows" do
        @feeder << [1,2,3] << [4,1,2] << [3,1,1] << [1,2,5]
        assert_equal Ruport.Table(%w[a b c], :data => [[2,2,3],[5,1,2],[4,1,1],[2,2,5]]),
                     @feeder.data
-     end     
-  end  
-  
+     end
+  end
+
   context "when using a feeder and a filter together" do
     setup do
       @feeder = Ruport::Data::Feeder.new(Ruport.Table(%w[a b c]))
-    end 
-    
+    end
+
     should "filter is called first when defined first" do
       @feeder.filter { |r| r.b != 2 }
       @feeder.transform { |r| r.b += 1 }
-      @feeder << [1,2,3] << [4,1,2] << [3,1,1] << [1,2,5] 
+      @feeder << [1,2,3] << [4,1,2] << [3,1,1] << [1,2,5]
       assert_equal Ruport.Table(%w[a b c], :data => [[4,2,2],[3,2,1]]),
                    @feeder.data
     end
-    
+
     should "transform is called first when defined first" do
-      @feeder.transform { |r| r.b += 1 }                    
-      @feeder.filter { |r| r.b != 2 }      
-      @feeder << [1,2,3] << [4,1,2] << [3,1,1] << [1,2,5] 
+      @feeder.transform { |r| r.b += 1 }
+      @feeder.filter { |r| r.b != 2 }
+      @feeder << [1,2,3] << [4,1,2] << [3,1,1] << [1,2,5]
       assert_equal Ruport.Table(%w[a b c], :data => [[1,3,3],[1,3,5]]),
                    @feeder.data
-    end 
-  end      
-  
+    end
+  end
+
   context "when using many feeders and filters together" do
     setup do
       @feeder = Ruport::Data::Feeder.new(Ruport.Table(%w[a b c]))
-      @feeder.transform { |r| r.a += 1 }      
+      @feeder.transform { |r| r.a += 1 }
       @feeder.filter { |r| r.a > 5 }
-      @feeder.transform { |r| r.b = r.b.to_s } 
-      @feeder.filter { |r| r.b == "3" } 
+      @feeder.transform { |r| r.b = r.b.to_s }
+      @feeder.filter { |r| r.b == "3" }
    end
-   
+
    should "all blocks are executed in order" do
-     @feeder << [1,2,3] << [4,1,9] << [5,3,1] << [2,3,0] << [7,3,5] 
+     @feeder << [1,2,3] << [4,1,9] << [5,3,1] << [2,3,0] << [7,3,5]
      assert_equal Ruport.Table(%w[a b c], :data => [[6,"3",1],[8,"3",5]]),
                   @feeder.data
-   end  
+   end
  end
-  
+
 end

--- a/test/grouping_test.rb
+++ b/test/grouping_test.rb
@@ -292,7 +292,7 @@ class TestGrouping < Minitest::Test
                                    ["banana",8,1] << ["dog",5,6] << ["dog",2,4] << ["banana",7,9]
     end
 
-    def specify_can_set_by_group_name_order_in_constructor
+    def test_specify_can_set_by_group_name_order_in_constructor
       a = Grouping(@table, :by => "a", :order => :name)
       names = %w[banana cat dog]
       data = [ [[8,1],[7,9]], [[3,5]], [[1,2],[5,6],[2,4]] ]
@@ -302,7 +302,7 @@ class TestGrouping < Minitest::Test
       end
     end
 
-    def specify_can_set_by_proc_ordering_in_constructor
+    def test_specify_can_set_by_proc_ordering_in_constructor
       a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )
       names = %w[dog banana cat]
       data = [ [[1,2],[5,6],[2,4]], [[8,1],[7,9]], [[3,5]] ]
@@ -312,7 +312,7 @@ class TestGrouping < Minitest::Test
       end
     end
 
-    def specify_can_override_sorting
+    def test_specify_can_override_sorting
       a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )
       a.sort_grouping_by!(:name)
       names = %w[banana cat dog]
@@ -323,7 +323,7 @@ class TestGrouping < Minitest::Test
       end
     end
 
-    def specify_can_get_a_new_sorted_grouping
+    def test_specify_can_get_a_new_sorted_grouping
       a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )
       b = a.sort_grouping_by(:name)
 

--- a/test/grouping_test.rb
+++ b/test/grouping_test.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby -w   
+#!/usr/bin/env ruby -w
 require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class TestGroup < Minitest::Test
@@ -8,7 +8,7 @@ class TestGroup < Minitest::Test
                                      :data => [[1,2,3]],
                                      :column_names => %w[a b c])
   end
-  
+
   def test_group_constructor
     group = Ruport::Data::Group.new(:name => 'test',
                                     :data => [[1,2,3]],
@@ -44,7 +44,7 @@ class TestGroup < Minitest::Test
     assert_equal @group, group2
     assert_equal @group, @group.dup
   end
-  
+
   def test_create_subgroups
     group = @group << [4,5,6]
     group.send(:create_subgroups, "a")
@@ -55,7 +55,7 @@ class TestGroup < Minitest::Test
                                         :column_names => %w[b c],
                                         :name => 4 ) }
     assert_equal b, group.subgroups
-    
+
     group.send(:create_subgroups, "b")
     c = { 2 => Ruport::Data::Group.new( :data => [[3]],
                                         :column_names => %w[c],
@@ -65,8 +65,8 @@ class TestGroup < Minitest::Test
                                         :name => 5 ) }
     assert_equal c, group.subgroups[1].subgroups
     assert_equal d, group.subgroups[4].subgroups
-  end    
-  
+  end
+
   def test_grouped_data
     a = @group << [4,5,6]
     b = { 1 => Ruport::Data::Group.new( :data => [[2,3]],
@@ -85,7 +85,7 @@ class TestGroupRendering < Minitest::Test
     @group = Ruport::Data::Group.new(:name => 'test',
                                      :data => [[1,2,3]],
                                      :column_names => %w[a b c])
-  end       
+  end
 
   def test_group_as
     assert_equal(7, @group.to_text.split("\n").size)
@@ -94,7 +94,7 @@ class TestGroupRendering < Minitest::Test
     assert_equal(15, @group.to_html.split("\n").size)
     assert_equal(8, @group.to_html(:show_table_headers => false).split("\n").size)
   end
-  
+
   def test_as_throws_proper_errors
     @group.as(:csv)
     @group.to_csv
@@ -111,14 +111,14 @@ class TestGroupRendering < Minitest::Test
     assert_equal "1\n\nb,c\n2,3\n", t.to_csv
   end
 end
-    
+
 class TestGrouping < Minitest::Test
-  
+
   def setup
     table = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
     @grouping = Ruport::Data::Grouping.new(table, :by => "a")
   end
-  
+
   def test_grouping_constructor
     a = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
     b = Ruport::Data::Grouping.new(a, :by => "a")
@@ -129,24 +129,24 @@ class TestGrouping < Minitest::Test
                                         :column_names => %w[b c],
                                         :name => 4 ) }
     assert_equal c, b.data
-  end        
-  
+  end
+
   def test_empty_grouping
     a = Ruport::Data::Grouping.new()
     a << Group("foo",:data => [[1,2,3],[4,5,6]],
                      :column_names => %w[a b c] )
-    assert_equal "foo", a["foo"].name    
-    assert_nil a.grouped_by         
-  end                               
-  
+    assert_equal "foo", a["foo"].name
+    assert_nil a.grouped_by
+  end
+
   def test_empty_grouping_with_grouped_by
-    a = Ruport::Data::Grouping.new(:by => "nada")  
+    a = Ruport::Data::Grouping.new(:by => "nada")
     a << Group("foo",:data => [[1,2,3],[4,5,6]],
                      :column_names => %w[a b c] )
-    assert_equal "foo", a["foo"].name    
+    assert_equal "foo", a["foo"].name
     assert_equal "nada", a.grouped_by
   end
-  
+
   def test_grouping_indexing
     a = [Ruport::Data::Group.new( :data => [[2,3]],
                                   :column_names => %w[b c],
@@ -160,8 +160,8 @@ class TestGrouping < Minitest::Test
     assert_equal a[0], @grouping[1]
     assert_equal a[1], @grouping[4]
     assert_raises(IndexError) { @grouping[2] }
-  end    
-  
+  end
+
   def test_should_copy_grouping
     a = { 1 => Ruport::Data::Group.new( :data => [[2,3]],
                                         :column_names => %w[b c],
@@ -178,10 +178,10 @@ class TestGrouping < Minitest::Test
    a = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
    @grouping << a.to_group("red snapper")
    assert_equal @grouping["red snapper"], a.to_group("red snapper")
-   
+
    assert_raises(ArgumentError) { @grouping << a.to_group("red snapper") }
   end
-  
+
   def test_grouped_by
     assert_equal "a", @grouping.grouped_by
   end
@@ -205,7 +205,7 @@ class TestGrouping < Minitest::Test
                                         :name => 5 ) }
     assert_equal d, b[1].subgroups
     assert_equal e, b[4].subgroups
-  end      
+  end
 
   def test_subgrouping
     a = Ruport.Table(%w[first_name last_name id])
@@ -220,7 +220,7 @@ class TestGrouping < Minitest::Test
     sub = (g / "mike")["milner"]
     assert_equal %w[schweet], sub.column("id")
   end
-  
+
   class TicketStatus < Ruport::Data::Record
 
     def closed
@@ -232,38 +232,38 @@ class TestGrouping < Minitest::Test
     end
 
   end
-  
+
   def test_grouping_summary
     source = Ruport.Table(File.join(File.expand_path(File.dirname(__FILE__)),
                    *%w[samples ticket_count.csv]),
                      :record_class => TicketStatus)
     grouping = Grouping(source,:by => "date")
-    
+
     expected = Ruport.Table(:date, :opened,:closed)
     grouping.each do |date,group|
       opened = group.sigma { |r| r.opened  }
       closed = group.sigma { |r| r.closed  }
       expected << { :date => date, :opened => opened, :closed => closed }
     end
-    
+
     actual = grouping.summary :date,
       :opened => lambda { |g| g.sigma(:opened) },
       :closed => lambda { |g| g.sigma(:closed) },
       :order => [:date,:opened,:closed]
-      
+
     assert_equal expected, actual
-    
+
     actual = grouping.summary :date,
       :opened => lambda { |g| g.sigma(:opened) },
       :closed => lambda { |g| g.sigma(:closed) }
-      
-    assert_equal [], expected.column_names - actual.column_names       
-  end                                                              
-  
+
+    assert_equal [], expected.column_names - actual.column_names
+  end
+
   def test_grouping_sigma
     assert_respond_to @grouping, :sigma
     assert_respond_to @grouping, :sum
-    
+
     expected = {}
     @grouping.data[@grouping.data.keys.first].column_names.each do |col|
       expected[col] = @grouping.inject(0) do |s, (group_name, group)|
@@ -286,66 +286,66 @@ class TestGrouping < Minitest::Test
   end
 
   describe "when sorting groupings" do
-    
+
     def setup
       @table = Ruport.Table(%w[a b c]) << ["dog",1,2] << ["cat",3,5] <<
                                    ["banana",8,1] << ["dog",5,6] << ["dog",2,4] << ["banana",7,9]
     end
-    
+
     def specify_can_set_by_group_name_order_in_constructor
-      a = Grouping(@table, :by => "a", :order => :name)    
-      names = %w[banana cat dog]           
+      a = Grouping(@table, :by => "a", :order => :name)
+      names = %w[banana cat dog]
       data = [ [[8,1],[7,9]], [[3,5]], [[1,2],[5,6],[2,4]] ]
       a.each do |name,group|
         assert_equal names.shift, name
-        assert_equal data.shift, group.map { |r| r.to_a } 
+        assert_equal data.shift, group.map { |r| r.to_a }
       end
     end
-    
+
     def specify_can_set_by_proc_ordering_in_constructor
-      a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } ) 
-      names = %w[dog banana cat]      
+      a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )
+      names = %w[dog banana cat]
       data = [ [[1,2],[5,6],[2,4]], [[8,1],[7,9]], [[3,5]] ]
       a.each do |name,group|
         assert_equal names.shift, name
-        assert_equal data.shift, group.map { |r| r.to_a } 
+        assert_equal data.shift, group.map { |r| r.to_a }
       end
-    end  
-    
+    end
+
     def specify_can_override_sorting
-      a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )  
+      a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )
       a.sort_grouping_by!(:name)
-      names = %w[banana cat dog]           
+      names = %w[banana cat dog]
       data = [ [[8,1],[7,9]], [[3,5]], [[1,2],[5,6],[2,4]] ]
       a.each do |name,group|
         assert_equal names.shift, name
-        assert_equal data.shift, group.map { |r| r.to_a } 
+        assert_equal data.shift, group.map { |r| r.to_a }
       end
-    end 
-    
+    end
+
     def specify_can_get_a_new_sorted_grouping
-      a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )  
-      b = a.sort_grouping_by(:name)     
-      
-      names = %w[banana cat dog]           
+      a = Grouping(@table, :by => "a", :order => lambda { |g| -g.length } )
+      b = a.sort_grouping_by(:name)
+
+      names = %w[banana cat dog]
       data = [ [[8,1],[7,9]], [[3,5]], [[1,2],[5,6],[2,4]] ]
       b.each do |name,group|
         assert_equal names.shift, name
-        assert_equal data.shift, group.map { |r| r.to_a } 
+        assert_equal data.shift, group.map { |r| r.to_a }
       end
-      
+
       # assert original retained
-      names = %w[dog banana cat]      
+      names = %w[dog banana cat]
       data = [ [[1,2],[5,6],[2,4]], [[8,1],[7,9]], [[3,5]] ]
       a.each do |name,group|
         assert_equal names.shift, name
-        assert_equal data.shift, group.map { |r| r.to_a } 
-      end   
+        assert_equal data.shift, group.map { |r| r.to_a }
+      end
     end
   end
- 
+
   class MyRecord < Ruport::Data::Record; end
-  
+
   def test_grouping_should_set_record_class
     a = Ruport.Table(%w[a b c], :record_class => MyRecord) { |t|
           t << [1,2,3]
@@ -353,13 +353,13 @@ class TestGrouping < Minitest::Test
         }
     b = Ruport::Data::Grouping.new(a, :by => "a")
     assert_equal MyRecord, b[1].record_class
-  end   
+  end
 
   class MyGroupingSub < Ruport::Data::Grouping; end
 
   def test_ensure_grouping_subclasses_render_properly
     t = Ruport.Table(%w[a b c]) << [1,2,3]
-    a = MyGroupingSub.new(t, :by => "a") 
+    a = MyGroupingSub.new(t, :by => "a")
     assert_equal "1\n\nb,c\n2,3\n\n", a.to_csv
   end
 end
@@ -370,7 +370,7 @@ class TestGroupingRendering < Minitest::Test
     table = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
     @grouping = Ruport::Data::Grouping.new(table, :by => "a")
   end
-  
+
   def test_grouping_as
     assert_equal(15, @grouping.to_text.split("\n").size)
     assert_equal(11, @grouping.as(:text,
@@ -379,7 +379,7 @@ class TestGroupingRendering < Minitest::Test
 
   def test_as_throws_proper_errors
      @grouping.as(:csv)
-     @grouping.to_csv 
+     @grouping.to_csv
     assert_raises(Ruport::Controller::UnknownFormatError) {
       @grouping.as(:nothing) }
     assert_raises(Ruport::Controller::UnknownFormatError) {
@@ -394,7 +394,7 @@ class TestGroupingKernelHacks < Minitest::Test
                                      :data => [[1,2,3]],
                                      :column_names => %w[a b c])
     assert_equal group, Group('test', :data => [[1,2,3]],
-                                      :column_names => %w[a b c]) 
+                                      :column_names => %w[a b c])
   end
 
   def test_grouping_kernel_hack

--- a/test/html_formatter_test.rb
+++ b/test/html_formatter_test.rb
@@ -1,8 +1,8 @@
-#!/usr/bin/env ruby -w  
+#!/usr/bin/env ruby -w
 require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class TestRenderHTMLTable < Minitest::Test
-  
+
   def setup
     Ruport::Formatter::Template.create(:simple) do |format|
       format.table = {
@@ -14,7 +14,7 @@ class TestRenderHTMLTable < Minitest::Test
       }
     end
   end
-  
+
   def test_html_table
     a = Ruport::Formatter::HTML.new
 
@@ -23,11 +23,11 @@ class TestRenderHTMLTable < Minitest::Test
   end
 
   def test_render_html_basic
-    
+
     actual = Ruport::Controller::Table.render_html { |r|
       r.data = Ruport.Table([], :data => [[1,2,3],[4,5,6]])
-    }          
-    
+    }
+
     assert_equal("\t<table>\n\t\t<tr>\n\t\t\t<td>1</td>\n\t\t\t<td>2"+
                  "</td>\n\t\t\t<td>3</td>\n\t\t</tr>\n\t\t<tr>\n\t\t"+
                  "\t<td>4</td>\n\t\t\t<td>5</td>\n\t\t\t<td>6</td>\n\t"+
@@ -36,21 +36,21 @@ class TestRenderHTMLTable < Minitest::Test
     actual = Ruport::Controller::Table.render_html { |r|
       r.data = Ruport.Table(%w[a b c], :data => [ [1,2,3],[4,5,6]])
     }
-    
+
     assert_equal("\t<table>\n\t\t<thead>\n\t\t<tr>\n\t\t\t<th>a</th>\n\t\t\t<th>b</th>"+
       "\n\t\t\t<th>c</th>\n\t\t</tr>\n\t\t</thead>\n\t\t<tr>\n\t\t\t<td>1</td>"+
       "\n\t\t\t<td>2</td>\n\t\t\t<td>3</td>\n\t\t</tr>\n\t\t<tr>"+
       "\n\t\t\t<td>4</td>\n\t\t\t<td>5</td>\n\t\t\t<td>6</td>\n\t"+
-      "\t</tr>\n\t</table>\n",actual)   
-    
+      "\t</tr>\n\t</table>\n",actual)
+
   end
-  
+
   def test_render_with_template
     formatter = Ruport::Formatter::HTML.new
     formatter.options = Ruport::Controller::Options.new
     formatter.options.template = :simple
     formatter.apply_template
-    
+
     assert_equal false, formatter.options.show_table_headers
 
     assert_equal :justified, formatter.options.style
@@ -72,7 +72,7 @@ class TestRenderHTMLTable < Minitest::Test
     ) do |r|
       opts = r.options
     end
-    
+
     assert_equal true, opts.show_table_headers
 
     assert_equal :inline, opts.style
@@ -90,27 +90,27 @@ class TestRenderHTMLTable < Minitest::Test
     ) do |r|
       opts = r.options
     end
-    
+
     assert_equal true, opts.show_table_headers
 
     assert_equal :inline, opts.style
     assert_equal true, opts.show_group_headers
   end
 end
-   
+
 
 class TestRenderHTMLRow < Minitest::Test
-  
+
   def test_render_html_row
     actual = Ruport::Controller::Row.render_html { |r| r.data = [1,2,3] }
     assert_equal("\t\t<tr>\n\t\t\t<td>1</td>\n\t\t\t<td>2"+
                  "</td>\n\t\t\t<td>3</td>\n\t\t</tr>\n",actual)
   end
 end
-   
+
 
 class TestRenderHTMLGroup < Minitest::Test
-    
+
   def test_render_html_group
     group = Ruport::Data::Group.new(:name => 'test',
                                     :data => [[1,2,3],[4,5,6]],
@@ -134,7 +134,7 @@ class TestRenderHTMLGroup < Minitest::Test
       "\n\t\t\t<td>2</td>\n\t\t\t<td>3</td>\n\t\t</tr>\n\t\t<tr>"+
       "\n\t\t\t<td>4</td>\n\t\t\t<td>5</td>\n\t\t\t<td>6</td>\n\t"+
       "\t</tr>\n\t</table>\n", actual
-  end                                           
+  end
 end
 
 
@@ -181,8 +181,8 @@ class TestRenderHTMLGrouping < Minitest::Test
                  "<td class=\"groupName\">2</td>\n\t\t\t<td>7</td>\n"+
                  "\t\t\t<td>9</td>\n\t\t</tr>\n\t</table>\n", actual
   end
-end  
-     
+end
+
 
 class TestHTMLFormatterHelpers < Minitest::Test
   begin
@@ -190,8 +190,8 @@ class TestHTMLFormatterHelpers < Minitest::Test
   rescue LoadError
     nil
   end
-  
-  def test_textile     
+
+  def test_textile
     require "redcloth"
     a = Ruport::Formatter::HTML.new
     assert_equal "<p><strong>foo</strong></p>", a.textile("*foo*")

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -1,75 +1,75 @@
-#!/usr/bin/env ruby -w   
+#!/usr/bin/env ruby -w
 require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class TestRecord < Minitest::Test
 
   include Ruport::Data
-  
+
   def setup
     @attributes = %w[a b c d]
-    @record = Ruport::Data::Record.new [1,2,3,4], :attributes => @attributes 
-  end   
-  
+    @record = Ruport::Data::Record.new [1,2,3,4], :attributes => @attributes
+  end
+
   describe "when initializing with an array with attributes" do
     def specify_key_access_should_work
       assert_equal 1, @record["a"]
       assert_equal 4, @record["d"]
       assert_equal 2, @record.b
       assert_equal 3, @record.c
-      assert_raises(NoMethodError) { @record.f }        
-    end  
-    
+      assert_raises(NoMethodError) { @record.f }
+    end
+
     def specify_ordinal_access_should_work
       assert_equal 1, @record[0]
       assert_equal 2, @record[1]
       assert_equal 3, @record[2]
       assert_equal 4, @record[3]
     end
-  end  
-      
+  end
+
   describe "when initializing with an array without attributes" do
     def specify_ordinal_access_should_work
       record = Ruport::Data::Record.new [1,2,3,4]
       assert_equal 1, record[0]
       assert_equal 2, record[1]
       assert_equal 3, record[2]
-      assert_equal 4, record[3]   
-    end 
-  end         
-  
+      assert_equal 4, record[3]
+    end
+  end
+
   describe "when initializing with a hash without attributes" do
-    def setup  
+    def setup
       @record = Ruport::Data::Record.new({:a => 1, :b => 2, :c => 3},{})
-    end     
-     
+    end
+
     def specify_key_access_should_work
       assert_equal 1, @record[:a]
       assert_equal 2, @record[:b]
       assert_equal 3, @record[:c]
-      assert_equal 3, @record.c  
-    end  
+      assert_equal 3, @record.c
+    end
   end
-  
+
   describe "when initializing with a hash with attributes" do
     def setup
-      @record = Record.new({:a => 1, :b => 2, :c => 3 }, 
+      @record = Record.new({:a => 1, :b => 2, :c => 3 },
                            :attributes => [:c,:b,:a])
-    end   
-    
+    end
+
     def specify_key_access_should_work
       assert_equal 1, @record[:a]
       assert_equal 2, @record[:b]
       assert_equal 3, @record[:c]
-      assert_equal 3, @record.c   
+      assert_equal 3, @record.c
     end
-    
-    def specify_ordinal_access_should_work    
+
+    def specify_ordinal_access_should_work
       assert_equal 3, @record[0]
-      assert_equal 2, @record[1]           
-      assert_equal 1, @record[2]           
+      assert_equal 2, @record[1]
+      assert_equal 1, @record[2]
     end
   end
-  
+
   def test_bracket_equals
     @record[1] = "godzilla"
     @record["d"] = "mothra"
@@ -80,16 +80,16 @@ class TestRecord < Minitest::Test
     assert_equal @record[3], "mothra"
     assert_equal @record["d"], "mothra"
   end
-    
+
   def test_accessors
     assert_equal @record.a, @record["a"]
     assert_equal @record.b, @record["b"]
     assert_equal @record.c, @record["c"]
     assert_equal @record.d, @record["d"]
-  end            
-  
+  end
+
   def test_can_has_id
-     record = Ruport::Data::Record.new(:id => 12345) 
+     record = Ruport::Data::Record.new(:id => 12345)
      assert_equal 12345, record.id
   end
 
@@ -98,7 +98,7 @@ class TestRecord < Minitest::Test
       @record.e
     end
   end
-  
+
   def test_attribute_setting
     @record.a = 10
     @record.b = 20
@@ -114,22 +114,22 @@ class TestRecord < Minitest::Test
   def test_to_hash
     @record.to_hash
     assert_equal({ "a" => 1, "b" => 2, "c" => 3, "d" => 4 }, @record.to_hash)
-  end  
-  
+  end
+
   def test_rename_attribute
      @record.rename_attribute("b","x")
      assert_equal %w[a x c d], @record.attributes
      assert_equal 2, @record["x"]
      assert_equal 2, @record.x
      assert_equal 2, @record[1]
-  end   
+  end
 
   def test_equality
 
     dc  = %w[a b c d]
     dc2 = %w[a b c d]
     dc3 = %w[a b c]
-    
+
     rec1 = Record.new [1,2,3,4]
     rec2 = Record.new [1,2,3,4]
     rec3 = Record.new [1,2]
@@ -137,7 +137,7 @@ class TestRecord < Minitest::Test
     rec5 = Record.new [1,2,3,4], :attributes => dc2
     rec6 = Record.new [1,2,3,4], :attributes => dc3
     rec7 = Record.new [1,2],     :attributes => dc
-    
+
     [:==, :eql?].each do |op|
       assert   rec1.send(op, rec2)
       assert   rec4.send(op, rec5)
@@ -162,7 +162,7 @@ class TestRecord < Minitest::Test
 
     assert_equal [1,2,3,4], @record.to_a
     assert_equal %w[a b c d], @record.attributes
-    
+
     @record.reorder "a","d","b","c"
     assert_equal [1,4,2,3], @record.to_a
     assert_equal %w[a d b c], @record.attributes
@@ -199,12 +199,12 @@ class TestRecord < Minitest::Test
     s = Record.new :attributes => %w[a b], :data => [1,2]
     assert_equal r.hash, s.hash
   end
-  
+
   def test_records_with_differing_attrs_and_data_hash_differently
     r = Record.new [1,2],:attributes => %w[a b]
     s = Record.new [nil,nil],:attributes => %w[a b]
     assert r.hash != s.hash
-    
+
     t = Record.new [1,3],:attributes => %w[a b]
     assert r.hash != t.hash
   end
@@ -225,7 +225,7 @@ class TestRecord < Minitest::Test
     new_object_id = @record.instance_variable_get(:@attributes).object_id
     assert_equal a.object_id, new_object_id
   end
-  
+
   #----------------------------------------------------------------------
   #  BUG Traps
   #----------------------------------------------------------------------
@@ -245,35 +245,35 @@ class TestRecord < Minitest::Test
   end
 
   # Ticket #172
-  def test_ensure_get_really_indifferent   
+  def test_ensure_get_really_indifferent
     a = Record.new({"a" => 1, "b" => 2})
     assert_equal(2,a.get("b"))
     assert_equal(2,a.get(:b))
-    a = Record.new({:a => 1, :b => 2})    
+    a = Record.new({:a => 1, :b => 2})
     assert_equal(2,a.get("b"))
     assert_equal(2,a.get(:b))
   end
-  
+
   def test_ensure_get_throws_argument_error
     a = Record.new({"a" => 1, "b" => 2})
     assert_raises(ArgumentError) { a.get([]) }
   end
-  
+
   def test_ensure_delete_removes_attribute
     a = Record.new({"a" => 1, "b" => 2})
     assert_equal({"a" => 1, "b" => 2}, a.data)
     assert_equal(["a","b"], a.attributes)
-    
+
     a.send(:delete, "a")
     assert_equal({"b" => 2}, a.data)
     assert_equal(["b"], a.attributes)
   end
-  
+
   def test_ensure_bracket_equals_updates_attributes
     a = Record.new({"a" => 1, "b" => 2})
     assert_equal({"a" => 1, "b" => 2}, a.data)
     assert_equal(["a","b"], a.attributes)
-    
+
     a["b"] = 3
     assert_equal({"a" => 1, "b" => 3}, a.data)
     assert_equal(["a","b"], a.attributes)
@@ -289,9 +289,9 @@ class TestRecord < Minitest::Test
     a = MyRecordSub.new [1,2,3]
     assert_equal "1,2,3\n", a.to_csv
   end
-    
+
   describe "when rendering records" do
-    
+
     def specify_record_as_should_work
       rendered_row = @record.as(:text)
       assert_equal("| 1 | 2 | 3 | 4 |\n", rendered_row)
@@ -299,34 +299,34 @@ class TestRecord < Minitest::Test
 
     def specify_record_to_format_should_work_without_options
       rendered_row = @record.to_text
-      assert_equal("| 1 | 2 | 3 | 4 |\n", rendered_row)    
-    end             
-         
+      assert_equal("| 1 | 2 | 3 | 4 |\n", rendered_row)
+    end
+
     def specify_record_to_format_should_work_with_options
       rendered_row = @record.to_csv(:format_options => { :col_sep => "\t"})
-      assert_equal("1\t2\t3\t4\n",rendered_row)     
-    end                                      
-    
+      assert_equal("1\t2\t3\t4\n",rendered_row)
+    end
+
     describe "when given bad format names" do
-      def setup 
-        @a = Record.new({ "a" => 1, "b" => 2 }) 
+      def setup
+        @a = Record.new({ "a" => 1, "b" => 2 })
       end
 
       def specify_as_should_throw_proper_errors
-        assert_raises(Ruport::Controller::UnknownFormatError) { @a.as(:nothing) } 
-      end 
-    
+        assert_raises(Ruport::Controller::UnknownFormatError) { @a.as(:nothing) }
+      end
+
       def specify_to_format_should_throw_proper_errors
         assert_raises(Ruport::Controller::UnknownFormatError) { @a.to_nothing }
-      end  
-    end   
-  
+      end
+    end
+
     ## -- BUG TRAPS --------------------
-  
+
     def specify_attributes_should_not_be_broken_by_to_hack
       record = Ruport::Data::Record.new [1,2], :attributes => %w[a to_something]
       assert_equal 2, record.to_something
-    end                              
+    end
   end
 
 end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -10,8 +10,8 @@ class TestRecord < Minitest::Test
     @record = Ruport::Data::Record.new [1,2,3,4], :attributes => @attributes
   end
 
-  describe "when initializing with an array with attributes" do
-    def specify_key_access_should_work
+  context "when initializing with an array with attributes" do
+    should "test_specify_key_access_should_work" do
       assert_equal 1, @record["a"]
       assert_equal 4, @record["d"]
       assert_equal 2, @record.b
@@ -19,7 +19,7 @@ class TestRecord < Minitest::Test
       assert_raises(NoMethodError) { @record.f }
     end
 
-    def specify_ordinal_access_should_work
+    should "test_specify_ordinal_access_should_work" do
       assert_equal 1, @record[0]
       assert_equal 2, @record[1]
       assert_equal 3, @record[2]
@@ -27,8 +27,8 @@ class TestRecord < Minitest::Test
     end
   end
 
-  describe "when initializing with an array without attributes" do
-    def specify_ordinal_access_should_work
+  context "when initializing with an array without attributes" do
+    should "test_specify_ordinal_access_should_work" do
       record = Ruport::Data::Record.new [1,2,3,4]
       assert_equal 1, record[0]
       assert_equal 2, record[1]
@@ -42,7 +42,7 @@ class TestRecord < Minitest::Test
       @record = Ruport::Data::Record.new({:a => 1, :b => 2, :c => 3},{})
     end
 
-    def specify_key_access_should_work
+    def test_specify_key_access_should_work
       assert_equal 1, @record[:a]
       assert_equal 2, @record[:b]
       assert_equal 3, @record[:c]
@@ -56,14 +56,14 @@ class TestRecord < Minitest::Test
                            :attributes => [:c,:b,:a])
     end
 
-    def specify_key_access_should_work
+    def test_specify_key_access_should_work
       assert_equal 1, @record[:a]
       assert_equal 2, @record[:b]
       assert_equal 3, @record[:c]
       assert_equal 3, @record.c
     end
 
-    def specify_ordinal_access_should_work
+    def test_specify_ordinal_access_should_work
       assert_equal 3, @record[0]
       assert_equal 2, @record[1]
       assert_equal 1, @record[2]
@@ -290,19 +290,19 @@ class TestRecord < Minitest::Test
     assert_equal "1,2,3\n", a.to_csv
   end
 
-  describe "when rendering records" do
+  context "when rendering records" do
 
-    def specify_record_as_should_work
+    should "test_specify_record_as_should_work" do
       rendered_row = @record.as(:text)
       assert_equal("| 1 | 2 | 3 | 4 |\n", rendered_row)
     end
 
-    def specify_record_to_format_should_work_without_options
+    should "test_specify_record_to_format_should_work_without_options" do
       rendered_row = @record.to_text
       assert_equal("| 1 | 2 | 3 | 4 |\n", rendered_row)
     end
 
-    def specify_record_to_format_should_work_with_options
+    should "test_specify_record_to_format_should_work_with_options" do
       rendered_row = @record.to_csv(:format_options => { :col_sep => "\t"})
       assert_equal("1\t2\t3\t4\n",rendered_row)
     end
@@ -312,18 +312,18 @@ class TestRecord < Minitest::Test
         @a = Record.new({ "a" => 1, "b" => 2 })
       end
 
-      def specify_as_should_throw_proper_errors
+      def test_specify_as_should_throw_proper_errors
         assert_raises(Ruport::Controller::UnknownFormatError) { @a.as(:nothing) }
       end
 
-      def specify_to_format_should_throw_proper_errors
+      def test_specify_to_format_should_throw_proper_errors
         assert_raises(Ruport::Controller::UnknownFormatError) { @a.to_nothing }
       end
     end
 
     ## -- BUG TRAPS --------------------
 
-    def specify_attributes_should_not_be_broken_by_to_hack
+    should "test_specify_attributes_should_not_be_broken_by_to_hack" do
       record = Ruport::Data::Record.new [1,2], :attributes => %w[a to_something]
       assert_equal 2, record.to_something
     end

--- a/test/table_pivot_test.rb
+++ b/test/table_pivot_test.rb
@@ -55,7 +55,7 @@ class PivotConvertRowOrderToGroupOrderTest < Minitest::Test
   end
 
   def test_nil
-    assert_equal(nil, convert(nil))
+    assert_nil convert(nil)
   end
 
 end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -41,14 +41,14 @@ class TestTable < Minitest::Test
       @data = [[1,2,3],[4,5,6],[7,8,9]]
     end
 
-    def specify_filters_should_discard_unmatched_rows
+    should "specify_filters_should_discard_unmatched_rows" do
       table = Ruport::Data::Table.new(:column_names => %w[a b c],
                                       :data => [[1,2,3],[4,5,6],[7,8,9]],
                                       :filters => [ lambda { |r| r.a % 2 == 1 } ] )
       assert_equal Ruport.Table(%w[a b c]) << [1,2,3] << [7,8,9], table
     end
 
-    def specify_filters_should_work_on_csvs
+    should "specify_filters_should_work_on_csvs" do
       only_ids_less_than_3 = lambda { |r| r["id"].to_i < 3 }
       table = Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"),
                     :filters => [only_ids_less_than_3])
@@ -58,11 +58,12 @@ class TestTable < Minitest::Test
 
   context "when transforming data" do
 
-    def setup
+    setup do
       @data = [[1,2,3],[4,5,6],[7,8,9]]
     end
 
-    def specify_transforms_should_modify_table_data
+    should "specify_transforms_should_modify_table_data" do
+
      stringify_c = lambda { |r| r.c = r.c.to_s }
      add_two_to_all_int_cols = lambda { |r|
       r.each_with_index do |c,i|
@@ -82,7 +83,7 @@ class TestTable < Minitest::Test
 
     end
 
-    def specify_transforms_should_work_on_csvs
+    should "specify_transforms_should_work_on_csvs" do
       ids_to_i = lambda { |r| r["id"] = r["id"].to_i }
       table = Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"),
                     :filters => [ids_to_i])
@@ -185,12 +186,12 @@ class TestTable < Minitest::Test
 
   context "when sorting rows" do
 
-    def setup
+    setup do
       @table = Ruport.Table(%w[a b c]) << [1,2,3] << [6,1,8] << [9,1,4]
       @table_with_nils = Ruport.Table(%w[a b c]) << [1,nil,3] << [9,3,4] << [6,1,8]
     end
 
-    def specify_should_sort_in_reverse_order_on_descending
+    should "specify_should_sort_in_reverse_order_on_descending" do
        t = @table.sort_rows_by("a", :order => :descending )
        assert_equal Ruport.Table(%w[a b c]) << [9,1,4] << [6,1,8] << [1,2,3], t
 
@@ -198,7 +199,7 @@ class TestTable < Minitest::Test
        assert_equal Ruport.Table(%w[a b c]) << [6,1,8] << [9,1,4] << [1,2,3], t
     end
 
-    def specify_show_put_rows_with_nil_columns_after_sorted_rows
+    should "specify_show_put_rows_with_nil_columns_after_sorted_rows" do
        # should not effect when using columns that are all populated
        t = @table_with_nils.sort_rows_by("a")
        assert_equal Ruport.Table(%w[a b c]) << [1,nil,3] << [6,1,8] << [9,3,4], t
@@ -210,12 +211,12 @@ class TestTable < Minitest::Test
        assert_equal Ruport.Table(%w[a b c]) << [1,nil,3] << [9,3,4] << [6,1,8], t
     end
 
-    def specify_in_place_sort_should_allow_order_by
+    should "specify_in_place_sort_should_allow_order_by" do
        @table.sort_rows_by!("a", :order => :descending )
        assert_equal Ruport.Table(%w[a b c]) << [9,1,4] << [6,1,8] << [1,2,3], @table
     end
 
-    def specify_sort_rows_by
+    should "specify_sort_rows_by" do
       table = Ruport::Data::Table.new :column_names => %w[a b c]
       table << [1,2,3] << [6,1,8] << [9,1,4]
 
@@ -240,7 +241,7 @@ class TestTable < Minitest::Test
       assert_equal sorted_table_bs, table2.sort_rows_by(:b)
     end
 
-    def specify_sort_rows_by!
+    should "specify_sort_rows_by!" do
       table = Ruport::Data::Table.new :column_names => %w[a b c]
       table << [1,2,3] << [6,1,8] << [9,1,4]
 
@@ -270,32 +271,32 @@ class TestTable < Minitest::Test
   end
 
   context "when adding rows" do
-    def setup
+    setup do
       @columns = %w[a b c]
       @data = [[1,2,3],[4,5,6],[7,8,9]]
       @table = Ruport::Data::Table.new(:column_names => @columns, :data => @data)
       @new_row = [-1,-2,-3]
     end
 
-    def specify_insert_at_the_beginning
+    should "specify_insert_at_the_beginning" do
       @table.add_row(@new_row, :position => 0)
       assert_equal Ruport::Data::Table.new(:column_names => @columns,
           :data => [@new_row] + @data), @table
     end
 
-    def specify_insert_in_the_middle
+    should "specify_insert_in_the_middle" do
       @table.add_row(@new_row, :position => 2)
       assert_equal Ruport::Data::Table.new(:column_names => @columns,
           :data => [[1,2,3],[4,5,6],[-1,-2,-3],[7,8,9]]), @table
     end
 
-    def specify_insert_at_the_end
+    should "specify_insert_at_the_end" do
       @table.add_row(@new_row)
       assert_equal Ruport::Data::Table.new(:column_names => @columns,
           :data => @data + [@new_row]), @table
     end
 
-    def should_return_itself
+    should "return_itself" do
       assert_equal @table.object_id, @table.add_row(@new_row).object_id
     end
   end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -335,7 +335,7 @@ class TestTable < Minitest::Test
     assert_equal %w[a b c], a.column_names
     a.each { |r|
       assert_equal %w[a b c], r.attributes
-      r.a; r.b; r.c 
+      r.a; r.b; r.c
       [r.a,r.b,r.c].each { |i| assert(i.kind_of?(Numeric)) }
     }
     assert_equal %w[d e f], b.column_names
@@ -366,7 +366,7 @@ class TestTable < Minitest::Test
       t << %w[joe loop]
     }
     assert_equal "joe loop", a[0].name
-    a.to_yaml 
+    a.to_yaml
   end
 
   def test_ensure_subtable_works_with_unnamed_tables
@@ -472,7 +472,7 @@ class TestTableFormattingHooks < Minitest::Test
   def test_as_throws_proper_errors
     a = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
     a.as(:csv)
-    a.to_csv 
+    a.to_csv
     assert_raises(Ruport::Controller::UnknownFormatError) { a.as(:nothing) }
     assert_raises(Ruport::Controller::UnknownFormatError) { a.to_nothing }
   end
@@ -692,9 +692,9 @@ class TestTableColumnOperations < Minitest::Test
 
   def test_ensure_renaming_a_missing_column_fails_silently
     a = Ruport.Table(%w[a b c])
-    
+
     a.rename_column("d", "z")
-    
+
   end
 
 end
@@ -741,9 +741,9 @@ class TestTableFromCSV < Minitest::Test
 
   # ticket:76
   def test_parse
-    
+
     Ruport::Data::Table.parse("a,b,c\n1,2,3\n")
-    
+
 
     table = Ruport::Data::Table.parse("a,b,c\n1,2,3\n4,5,6\n")
     expected = Ruport.Table(%w[a b c], :data => [%w[1 2 3],%w[4 5 6]])

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -1,31 +1,31 @@
 #!/usr/bin/env ruby -w
-require File.join(File.expand_path(File.dirname(__FILE__)), "helpers") 
+require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class TemplateTest < Minitest::Test
-  
+
   def setup
     @template_class = Ruport::Formatter::Template.dup
   end
-  
+
   def teardown
     Ruport::Formatter::Template.instance_variable_set(:@templates, nil)
   end
-   
+
   def test_template_should_exist
     @template_class.create(:foo)
-    assert_instance_of @template_class, 
+    assert_instance_of @template_class,
                        @template_class[:foo]
-  end  
-  
+  end
+
   def test_template_creation_yields_an_options_object
     @template_class.create(:foo) do |template|
       template.page_format = { :layout     => :landscape,
                                :paper_size => :letter    }
     end
     assert_equal :landscape, @template_class[:foo].page_format[:layout]
-    assert_equal :letter, @template_class[:foo].page_format[:paper_size]     
+    assert_equal :letter, @template_class[:foo].page_format[:paper_size]
   end
-  
+
   def test_create_derived_template
     Ruport::Formatter::Template.create(:foo) do |template|
       template.page_format = { :layout     => :landscape,
@@ -35,14 +35,14 @@ class TemplateTest < Minitest::Test
     assert_equal :landscape,
       Ruport::Formatter::Template[:bar].page_format[:layout]
     assert_equal :letter,
-      Ruport::Formatter::Template[:bar].page_format[:paper_size]     
+      Ruport::Formatter::Template[:bar].page_format[:paper_size]
   end
-  
+
   def test_default_template
     assert_nil Ruport::Formatter::Template.default
     Ruport::Formatter::Template.create(:default)
     assert_equal Ruport::Formatter::Template[:default],
       Ruport::Formatter::Template.default
   end
-  
+
 end

--- a/test/text_formatter_test.rb
+++ b/test/text_formatter_test.rb
@@ -2,7 +2,7 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "helpers")
 
 class TestRenderTextTable < Minitest::Test
-  
+
   def setup
     Ruport::Formatter::Template.create(:simple) do |format|
       format.table = {
@@ -22,50 +22,50 @@ class TestRenderTextTable < Minitest::Test
 
   def test_basic
     tf = "+-------+\n"
-    
+
     a = Ruport.Table([], :data => [[1,2],[3,4]]).to_text
     assert_equal("#{tf}| 1 | 2 |\n| 3 | 4 |\n#{tf}",a)
 
     a = Ruport.Table(%w[a b], :data => [[1,2],[3,4]]).to_text
     assert_equal("#{tf}| a | b |\n#{tf}| 1 | 2 |\n| 3 | 4 |\n#{tf}", a)
   end
-  
+
   def test_centering
-    tf = "+---------+\n" 
+    tf = "+---------+\n"
 
     a = Ruport.Table([], :data => [[1,2],[300,4]])
     assert_equal( "#{tf}|  1  | 2 |\n| 300 | 4 |\n#{tf}",
                   a.to_text(:alignment => :center) )
 
     tf = "+------------+\n"
-    a.column_names = %w[a bark]     
+    a.column_names = %w[a bark]
     assert_equal("#{tf}|  a  | bark |\n#{tf}|  1  |  2   |\n"+
-                 "| 300 |  4   |\n#{tf}", a.to_text(:alignment => :center) )   
+                 "| 300 |  4   |\n#{tf}", a.to_text(:alignment => :center) )
   end
 
   def test_justified
     tf = "+----------+\n"
     a = Ruport.Table([], :data => [[1,'Z'],[300,'BB']])
-    
+
     # justified alignment can be set explicitly
-    assert_equal "#{tf}|   1 | Z  |\n| 300 | BB |\n#{tf}", 
-                 a.to_text(:alignment => :justified)    
-    
-    # justified alignment is also default             
-    assert_equal "#{tf}|   1 | Z  |\n| 300 | BB |\n#{tf}", a.to_s      
+    assert_equal "#{tf}|   1 | Z  |\n| 300 | BB |\n#{tf}",
+                 a.to_text(:alignment => :justified)
+
+    # justified alignment is also default
+    assert_equal "#{tf}|   1 | Z  |\n| 300 | BB |\n#{tf}", a.to_s
   end
 
-  def test_wrapping  
+  def test_wrapping
     a = Ruport.Table([], :data => [[1,2],[300,4]]).to_text(:table_width => 10)
     assert_equal("+------->>\n|   1 | >>\n| 300 | >>\n+------->>\n",a)
-  end  
-  
+  end
+
   def test_ignore_wrapping
-    a = Ruport.Table([], :data => [[1,2],[300,4]]).to_text(:table_width => 10, 
+    a = Ruport.Table([], :data => [[1,2],[300,4]]).to_text(:table_width => 10,
                                          :ignore_table_width => true )
     assert_equal("+---------+\n|   1 | 2 |\n| 300 | 4 |\n+---------+\n",a)
-  end 
-  
+  end
+
   def test_render_empty_table
     assert_raises(Ruport::FormatterError) { Ruport.Table([]).to_text }
     Ruport.Table(%w[a b c]).to_text
@@ -76,13 +76,13 @@ class TestRenderTextTable < Minitest::Test
                "+-----------+\n"
     assert_equal expected, a
   end
-  
+
   def test_render_with_template
     formatter = Ruport::Formatter::Text.new
     formatter.options = Ruport::Controller::Options.new
     formatter.options.template = :simple
     formatter.apply_template
-    
+
     assert_equal false, formatter.options.show_table_headers
     assert_equal 50, formatter.options.table_width
     assert_equal true, formatter.options.ignore_table_width
@@ -92,7 +92,7 @@ class TestRenderTextTable < Minitest::Test
 
     assert_equal false, formatter.options.show_group_headers
   end
-  
+
   def test_options_hashes_override_template
     opts = nil
     table = Ruport.Table(%w[a b c])
@@ -113,7 +113,7 @@ class TestRenderTextTable < Minitest::Test
     ) do |r|
       opts = r.options
     end
-    
+
     assert_equal true, opts.show_table_headers
     assert_equal 25, opts.table_width
     assert_equal false, opts.ignore_table_width
@@ -138,7 +138,7 @@ class TestRenderTextTable < Minitest::Test
     ) do |r|
       opts = r.options
     end
-    
+
     assert_equal true, opts.show_table_headers
     assert_equal 75, opts.table_width
     assert_equal false, opts.ignore_table_width
@@ -148,7 +148,7 @@ class TestRenderTextTable < Minitest::Test
 
     assert_equal true, opts.show_group_headers
   end
-                                             
+
   # -- BUG TRAPS ------------------------------
 
   def test_should_render_without_column_names
@@ -158,9 +158,9 @@ class TestRenderTextTable < Minitest::Test
                "+-----------+\n"
     assert_equal(expected,a)
   end
-  
+
 end
-    
+
 
 class TestRenderTextRow < Minitest::Test
 
@@ -170,7 +170,7 @@ class TestRenderTextRow < Minitest::Test
   end
 
 end
-        
+
 
 class TestRenderTextGroup < Minitest::Test
 
@@ -196,7 +196,7 @@ class TestRenderTextGroup < Minitest::Test
                                    :data => [ %w[is this more],
                                               %w[interesting red snapper]],
                                    :column_names => %w[i hope so])
-   
+
     actual = Ruport::Controller::Group.render(:text, :data => group,
       :show_table_headers => false )
     expected = "test:\n\n"+
@@ -205,9 +205,9 @@ class TestRenderTextGroup < Minitest::Test
                "| interesting | red  | snapper |\n"+
                "+------------------------------+\n"
     assert_equal(expected, actual)
-  end                                           
-end       
-       
+  end
+end
+
 
 class TestRenderTextGrouping < Minitest::Test
 
@@ -230,8 +230,8 @@ class TestRenderTextGrouping < Minitest::Test
                "+-------------+\n"+
                "| this | more |\n"+
                "+-------------+\n\n"
-    assert_equal(expected, actual)  
-    
+    assert_equal(expected, actual)
+
     actual = grouping.to_s
     assert_equal(expected,actual)
   end
@@ -254,5 +254,5 @@ class TestRenderTextGrouping < Minitest::Test
                "+-------------+\n\n"
     assert_equal(expected, actual)
   end
-  
+
 end


### PR DESCRIPTION
- Remove trailing whitespace in test suites
- Make all the UTs run in the test suite (40+ tests were not running at all)