### PR TITLE
Warnings

### DIFF
--- a/examples/row_renderer.rb
+++ b/examples/row_renderer.rb
@@ -6,7 +6,7 @@ class CSV2Something < Ruport::Controller
 
   module Helpers
     def table_feeder
-      Table(options.csv_file,:has_names => false) { |t,r| yield(r) }
+      Table(options.csv_file,:has_names => false) { |_t,r| yield(r) }
     end
   end
 

--- a/examples/simple_pdf_lines.rb
+++ b/examples/simple_pdf_lines.rb
@@ -18,7 +18,7 @@ class PDFLines < Ruport::Formatter::PDF
 end
 
 # generate 35 random lines
-data = (0..34).inject([]) { |s,r|
+data = (0..34).inject([]) { |s,_r|
   s << [rand(100),100+rand(400)]
 }
 

--- a/examples/trac_ticket_status.rb
+++ b/examples/trac_ticket_status.rb
@@ -41,7 +41,7 @@ class TracSummaryReport
     Grouping(table,:by => :date)
   end
 
-  def renderable_data(format)
+  def renderable_data(_format)
     summary = feed_data.summary :date,
       :opened => lambda { |g| g.sigma { |r| r.opened  } },
       :closed => lambda { |g| g.sigma { |r| r.closed  } },

--- a/lib/ruport.rb
+++ b/lib/ruport.rb
@@ -96,7 +96,6 @@ module Ruport #:nodoc:#
 end  
 
 require "ruport/version"
-require "enumerator"
 require "ruport/controller" 
 require "ruport/data" 
 require "ruport/formatter" 

--- a/lib/ruport.rb
+++ b/lib/ruport.rb
@@ -60,8 +60,7 @@ module Ruport #:nodoc:#
         stdout_handle = m_GetStdHandle.call(0xFFFFFFF5)
         
         m_GetConsoleScreenBufferInfo.call(stdout_handle, buf)
-        bufx, bufy, curx, cury, wattr,
-        left, top, right, bottom, maxx, maxy = buf.unpack(format)
+        _bufx, _bufy, _curx, _cury, _wattr, left, top, right, bottom, _maxx, _maxy = buf.unpack(format)
         return right - left + 1, bottom - top + 1
       end
     rescue LoadError             # If we're not on Windows try...
@@ -76,13 +75,11 @@ module Ruport #:nodoc:#
         end 
         return $? == 0 ? size : [80,24] 
       end
-
-   end
+    end
    
-   def terminal_width
-     terminal_size.first
-   end
-
+    def terminal_width
+      terminal_size.first
+    end
   end
 
   # quiets warnings for block

--- a/lib/ruport/data/grouping.rb
+++ b/lib/ruport/data/grouping.rb
@@ -285,7 +285,7 @@ module Ruport::Data
       else 
         cols = procs.keys + [field]   
       end
-      expected = Table.new(:column_names => cols) { |t|
+      Table.new(:column_names => cols) { |t|
         each do |name,group|
           t << procs.inject({field => name}) do |s,r|
             s.merge(r[0] => r[1].call(group))
@@ -327,7 +327,7 @@ module Ruport::Data
     #   grouping.sigma { |r| r.col2 + 1 } #=> 15
     #
     def sigma(column=nil)
-      inject(0) do |s, (group_name, group)|
+      inject(0) do |s, (_group_name, group)|
         if column
           s + group.sigma(column)
         else

--- a/lib/ruport/data/grouping.rb
+++ b/lib/ruport/data/grouping.rb
@@ -99,7 +99,7 @@ module Ruport::Data
       if @subgroups.empty?
         @subgroups = grouped_data(group_column)
       else
-        @subgroups.each {|name,group|
+        @subgroups.each {|_name,group|
           group.send(:create_subgroups, group_column)
         }
       end
@@ -172,7 +172,7 @@ module Ruport::Data
         cols = Array(options[:by]).dup
         @data = data.to_group.send(:grouped_data, cols.shift)
         cols.each do |col|
-          @data.each do |name,group|
+          @data.each do |_name,group|
             group.send(:create_subgroups, col)
           end
         end    
@@ -200,9 +200,9 @@ module Ruport::Data
     #
     def each 
       if @order.respond_to?(:call) 
-        @data.sort_by { |n,g| @order[g] }.each { |n,g| yield(n,g) }
+        @data.sort_by { |_n,g| @order[g] }.each { |n,g| yield(n,g) }
       elsif @order == :name
-        @data.sort_by { |n,g| n }.each { |name,group| yield(name,group) } 
+        @data.sort_by { |n,_g| n }.each { |name,group| yield(name,group) }
       else
         @data.each { |name,group| yield(name,group) }
       end
@@ -216,7 +216,7 @@ module Ruport::Data
     #   by_size = grouping.sort_grouping_by { |g| g.size }
     def sort_grouping_by(type=nil,&block)
       a = Grouping.new(:by => @grouped_by, :order => type || block)
-      each { |n,g| a << g }
+      each { |_n,g| a << g }
       return a
     end
                                                           

--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -259,7 +259,7 @@ module Ruport::Data
         table = self.new(options) do |feeder|
           first_line = true
 
-          ::CSV.send(msg,param,options[:csv_options]) do |row|
+          ::CSV.send(msg,param, **options[:csv_options]) do |row|
             if first_line
               adjust_for_headers(feeder.data,row,options)
               first_line = false

--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -71,10 +71,10 @@ module Ruport::Data
       end
 
       def values
-        @values ||= Hash.new do |values, column_entry|
+        @values ||= Hash.new do |row_values, column_entry|
           rows_group = rows_groups[column_entry]
 
-          values[column_entry] =
+          row_values[column_entry] =
             row.inject({}) do |values, row_entry|
               matching_rows = rows_group.rows_with(@pivot_column => row_entry)
               values[row_entry] = perform_operation(matching_rows)

--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -50,7 +50,7 @@ module Ruport::Data
         ordering = self.class.row_order_to_group_order(@pivot_order)
         pivot_column_grouping.sort_grouping_by!(ordering) if ordering
 
-        @row = pivot_column_grouping.map { |name,grouping| name }
+        @row = pivot_column_grouping.map { |name,_grouping| name }
       end
 
       # Column in the first column in the pivoted table (without the group column)
@@ -132,7 +132,7 @@ module Ruport::Data
           rows && rows.inject(0) { |sum,row| sum+row[summary_column] }
         end
 
-        def count(rows, summary_column)
+        def count(rows, _summary_column)
           rows && rows.length
         end
 

--- a/lib/ruport/formatter/csv.rb
+++ b/lib/ruport/formatter/csv.rb
@@ -55,7 +55,7 @@ module Ruport
     #
     def csv_writer
       @csv_writer ||= options.formatter ||
-        ::CSV.instance(output, options.format_options || {})
+        ::CSV.instance(output, **(options.format_options || {}))
     end
 
     # Generates table header by turning column_names into a CSV row.

--- a/lib/ruport/formatter/text.rb
+++ b/lib/ruport/formatter/text.rb
@@ -110,7 +110,7 @@ module Ruport
     def build_row(data = self.data)
       max_col_widths_for_row(data) unless options.max_col_width
 
-      data.enum_for(:each_with_index).inject(line=[]) { |s,e|
+      data.enum_for(:each_with_index).inject(line=[]) { |_s,e|
         field,index = e
         if options.alignment.eql? :center
           line << field.to_s.center(options.max_col_width[index])

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -688,7 +688,7 @@ class TestControllerHooks < Minitest::Test
     include Ruport::Controller::Hooks
     renders_as_table
 
-    def renderable_data(format)
+    def renderable_data(_format)
       1
     end
   end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -156,7 +156,7 @@ class TestController < Minitest::Test
   def test_using_io
     require "stringio"
     out = StringIO.new
-    a = OldSchoolController.render(:text) { |r| r.io = out }
+    OldSchoolController.render(:text) { |r| r.io = out }
     out.rewind
     assert_equal "header\nbody\nfooter\n", out.read
     assert_equal "", out.read
@@ -165,7 +165,7 @@ class TestController < Minitest::Test
   def test_using_file
     f = []
     File.expects(:open).yields(f)
-    a = OldSchoolController.render(:text, :file => "foo.text")
+    OldSchoolController.render(:text, :file => "foo.text")
     assert_equal "header\nbody\nfooter\n", f[0]
 
     f = []
@@ -305,30 +305,28 @@ class TestControllerWithManyHooks < Minitest::Test
     def setup
       options.apple = true
     end
-
   end
 
   def test_hash_options_setters
-    a = ControllerWithManyHooks.render(:text, :subtitle => "foo",
-                                       :subsubtitle => "bar") { |r|
+    ControllerWithManyHooks.render(:text, :subtitle => "foo", :subsubtitle => "bar") do |r|
       assert_equal "foo", r.options.subtitle
       assert_equal "bar", r.options.subsubtitle
-    }
+    end
   end
 
   def test_data_accessors
-   a = ControllerWithManyHooks.render(:text, :data => [1,2,4]) { |r|
-     assert_equal [1,2,4], r.data
-   }
+    ControllerWithManyHooks.render(:text, :data => [1,2,4]) do |r|
+      assert_equal [1,2,4], r.data
+    end
 
-   b = ControllerWithManyHooks.render_text(%w[a b c]) { |r|
-     assert_equal %w[a b c], r.data
-   }
+    ControllerWithManyHooks.render_text(%w[a b c]) do |r|
+      assert_equal %w[a b c], r.data
+    end
 
-   c = ControllerWithManyHooks.render_text(%w[a b f],:snapper => :red) { |r|
-     assert_equal %w[a b f], r.data
-     assert_equal :red, r.options.snapper
-   }
+    ControllerWithManyHooks.render_text(%w[a b f],:snapper => :red) do |r|
+      assert_equal %w[a b f], r.data
+      assert_equal :red, r.options.snapper
+    end
   end
 
   def test_formatter_data_dup

--- a/test/grouping_test.rb
+++ b/test/grouping_test.rb
@@ -266,7 +266,7 @@ class TestGrouping < Minitest::Test
 
     expected = {}
     @grouping.data[@grouping.data.keys.first].column_names.each do |col|
-      expected[col] = @grouping.inject(0) do |s, (group_name, group)|
+      expected[col] = @grouping.inject(0) do |s, (_group_name, group)|
         s + group.sigma(col)
       end
     end
@@ -276,7 +276,7 @@ class TestGrouping < Minitest::Test
 
     expected = {}
     @grouping.data[@grouping.data.keys.first].column_names.each do |col|
-      expected[col] = @grouping.inject(0) do |s, (group_name, group)|
+      expected[col] = @grouping.inject(0) do |s, (_group_name, group)|
         s + group.sigma {|r| r[col] + 2 }
       end
     end

--- a/test/helpers.rb
+++ b/test/helpers.rb
@@ -16,12 +16,8 @@ end
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 require 'ruport'
-begin; require 'rubygems'; rescue LoadError; nil; end
-
-
 require 'minitest'
 require 'minitest/autorun'
-
 require 'minitest/spec'
 require 'minitest/unit'
 require 'shoulda-context'

--- a/test/table_pivot_test.rb
+++ b/test/table_pivot_test.rb
@@ -132,7 +132,7 @@ class PivotPreservesOrdering < Minitest::Test
     ].each {|e| table << e}
     table.add_column('pivotme') {|row| 10 - row.group.to_i}
     pivoted = table.pivot('pivotme', :group_by => 'group', :values => 'a',
-                                     :pivot_order => proc {|row, pivot| pivot })
+                                     :pivot_order => proc {|_row, pivot| pivot })
     assert_equal(['group', 7, 8, 9], pivoted.column_names)
   end
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -719,7 +719,7 @@ class TestTableFromCSV < Minitest::Test
 
     table = Ruport::Data::Table.load( File.join(TEST_SAMPLES,"data.csv"),
       :csv_options => { :headers => true, :header_converters => :symbol }
-      ) do |s,r|
+      ) do |_s,r|
         assert_equal expected.shift, r[:col3]
       end
 
@@ -728,7 +728,7 @@ class TestTableFromCSV < Minitest::Test
     expected = ['c','e']
 
     Ruport::Data::Table.load( File.join(TEST_SAMPLES,"data.csv"),
-                              :records => true ) do |s,r|
+                              :records => true ) do |_s,r|
       assert_equal expected.shift, r.col3
       assert_kind_of Ruport::Data::Record, r
     end
@@ -796,7 +796,7 @@ class TestTableFromCSV < Minitest::Test
   end
 
   def test_ensure_table_from_csv_accepts_record_class_in_block_usage
-    Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"), :record_class => DuckRecord, :records => true) do |s,r|
+    Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"), :record_class => DuckRecord, :records => true) do |_s,r|
       assert_kind_of(DuckRecord,r)
     end
   end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -25,7 +25,7 @@ class TestTable < Minitest::Test
       assert_equal n, t.column_names
 
       t = Ruport.Table(%w[a b c], :data => [[1,2,3],[4,5,6]])
-      table_from_records = Ruport.Table(t.column_names, :data => t.data)
+      Ruport.Table(t.column_names, :data => t.data)
     end
 
     a = Ruport::Data::Record.new [1,2,3]
@@ -791,27 +791,21 @@ class TestTableFromCSV < Minitest::Test
   end
 
   def test_ensure_csv_loading_accepts_table_options
-     a = Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"),
-                 :record_class => DuckRecord)
-     a.each { |r| assert_kind_of(DuckRecord,r) }
+    a = Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"), :record_class => DuckRecord)
+    a.each { |r| assert_kind_of(DuckRecord,r) }
   end
 
   def test_ensure_table_from_csv_accepts_record_class_in_block_usage
-    a = Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"),
-                :record_class => DuckRecord, :records => true) do |s,r|
-       assert_kind_of(DuckRecord,r)
+    Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"), :record_class => DuckRecord, :records => true) do |s,r|
+      assert_kind_of(DuckRecord,r)
     end
   end
-
 end
 
 class TestTableKernelHack < Minitest::Test
-
   def test_simple
-    assert_equal Ruport::Data::Table.new(:column_names => %w[a b c]),
-      Ruport.Table(%w[a b c])
-    assert_equal Ruport::Data::Table.new(:column_names => %w[a b c]),
-      Ruport.Table("a","b","c")
+    assert_equal Ruport::Data::Table.new(:column_names => %w[a b c]), Ruport.Table(%w[a b c])
+    assert_equal Ruport::Data::Table.new(:column_names => %w[a b c]), Ruport.Table("a","b","c")
     assert_equal Ruport::Data::Table.load(
                  File.join(TEST_SAMPLES,"addressbook.csv")),
                  Ruport.Table(File.join(TEST_SAMPLES,"addressbook.csv"))
@@ -863,5 +857,4 @@ class TestTableKernelHack < Minitest::Test
     assert_equal Ruport::Data::Table.new(:column_names => %w[a b c]),
                  Ruport.Table(:column_names => %w[a b c])
   end
-
 end

--- a/util/bench/data/table/bench_column_manip.rb
+++ b/util/bench/data/table/bench_column_manip.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 

--- a/util/bench/data/table/bench_dup.rb
+++ b/util/bench/data/table/bench_dup.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 include Ruport::Bench

--- a/util/bench/data/table/bench_init.rb
+++ b/util/bench/data/table/bench_init.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 

--- a/util/bench/data/table/bench_manip.rb
+++ b/util/bench/data/table/bench_manip.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 

--- a/util/bench/formatter/bench_csv.rb
+++ b/util/bench/formatter/bench_csv.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 include Ruport::Bench

--- a/util/bench/formatter/bench_html.rb
+++ b/util/bench/formatter/bench_html.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 include Ruport::Bench

--- a/util/bench/formatter/bench_pdf.rb
+++ b/util/bench/formatter/bench_pdf.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 include Ruport::Bench

--- a/util/bench/formatter/bench_text.rb
+++ b/util/bench/formatter/bench_text.rb
@@ -1,5 +1,4 @@
 require "ruport"
-require "enumerator"
 require "rubygems"
 require "ruport/util/bench"
 include Ruport::Bench


### PR DESCRIPTION
remove basic warnings for ruby 2.7

Fixes #46 

The change of `value` -> `row_value` is my main concern for introducing a bug. I may have misunderstood which `value` it was intending. the making variable or the maskee.