### PR TITLE
remove references to rubyreports.org

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -23,23 +23,7 @@ contributions to our project.  Here are a few different ways you can help.
 If any of these things sound appealing to you, there are a few things
 you should do:
 
-1) Sign up on the mailing list: http://list.rubyreports.org/
-
-2) Post and introduce yourself, letting us know what you'd like to work on OR
-   Find sandal or mikem836 on #ruport
-
-3) Please read the MakingChangeRequests, ReportingDefects, and
-   SubmittingPatches Trac wiki pages, as appropriate.
-
-   - http://stonecode.svnrepository.com/ruport/trac.cgi/wiki/MakingChangeRequests
-
-   - http://stonecode.svnrepository.com/ruport/trac.cgi/wiki/ReportingDefects
-
-   - http://stonecode.svnrepository.com/ruport/trac.cgi/wiki/SubmittingPatches
-
-4) Please pull the latest code from SVN trunk:
-   http://stonecode.svnrepository.com/svn/ruport/ruport/trunk
-
+1) Head over to https://github.com/ruport/ruport
 
 This should hopefully be enough to get you on the right track.  We welcome your
 questions and ideas, so don't be afraid to contact us.

--- a/lib/ruport/data/table.rb
+++ b/lib/ruport/data/table.rb
@@ -560,8 +560,8 @@ module Ruport::Data
     #   data.add_columns ['new_column_1','new_column_2'], :default => 1
     #
     def add_columns(names,options={})
-      raise "Greg isn't smart enough to figure this out.\n"+
-            "Send ideas in at http://list.rubyreports.org" if block_given?
+      raise "Greg isn't smart enough to figure this out.\n" \
+            "Send ideas in at github" if block_given?
       need_reverse = !!(options[:after] || options[:position])
       names = names.reverse if need_reverse
       names.each { |n| add_column(n,options) }


### PR DESCRIPTION
The domain is no longer valid

Pointing to github that holds our current master implementation.

related to #20