### PR TITLE
Fix stty error message

### DIFF
--- a/lib/ruport.rb
+++ b/lib/ruport.rb
@@ -67,11 +67,11 @@ module Ruport #:nodoc:#
       # A Unix savvy method to fetch the console columns, and rows.
       def terminal_size
         size = if /solaris/ =~ RUBY_PLATFORM
-          output = `stty`
+          output = `stty 2>&1`
           [output.match('columns = (\d+)')[1].to_i,
           output.match('rows = (\d+)')[1].to_i]
         else
-           `stty size`.split.map { |x| x.to_i }.reverse
+           `stty size 2>&1`.split.map { |x| x.to_i }.reverse
         end 
         return $? == 0 ? size : [80,24] 
       end


### PR DESCRIPTION
When stdin is redirected in, it is able to default to 80 columns
but it is displaying a warning in the console

See PR comments for more info

Fixes #25

## reproducer

```ruby
#!/usr/bin/env ruby

$LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
require 'ruport'

tbl = Ruport::Data::Table.new(:column_names => [ :lines ])
$stdin.each{|line| tbl << line.strip.split(',') }
puts tbl.to_text
```

## before

```
$ uname -v
Darwin Kernel Version 17.7.0: Tue Feb 18 22:51:29 PST 2020; root:xnu-4570.71.73~1/RELEASE_X86_64
$ echo -e "a\nb" | ruby ./tst.rb 
stty: stdin isn't a terminal
+-------+
| lines |
+-------+
| a     |
| b     |
+-------+
```

## after

```
$ uname -v
Darwin Kernel Version 17.7.0: Tue Feb 18 22:51:29 PST 2020; root:xnu-4570.71.73~1/RELEASE_X86_64
$ echo -e "a\nb" | ruby ./tst.rb 
+-------+
| lines |
+-------+
| a     |
| b     |
+-------+
```
