### PR TITLE
1.8.0 - 2022-09-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - undecided
+
+## [1.8.0] - 2022-09-20
+
+### Added
+
+- Markdown formatter [#54](https://github.com/ruport/ruport/pull/54)
+- Ruby 3.0 support
+
+### Changed
+
+- Reduced allocations to improve performance [#34](https://github.com/ruport/ruport/pull/34)
+- Update Prawn version to 2.4.0 [#44](https://github.com/ruport/ruport/pull/44) [#57](https://github.com/ruport/ruport/pull/57) [#64](https://github.com/ruport/ruport/pull/64)
+
+## [1.7.1] - 2017-05-02
+
+### Changed
+
+- Improved errors when missing gems.
+- Added ruby 1.9 support
+- Removed dependency on `fastercsv` gem
+
+## [1.7.0] - 2011-01-06
+
+## [1.6.3] - 2009-12-12
+
+
+[Unreleased]: https://github.com/ruport/ruport/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/ruport/ruport/compare/v1.7.1...v1.8.0
+[1.7.1]: https://github.com/ruport/ruport/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/ruport/ruport/compare/v1.6.3...v1.7.0
+[1.6.3]: https://github.com/ruport/ruport/compare/v1.6.2...v1.6.3

--- a/lib/ruport/version.rb
+++ b/lib/ruport/version.rb
@@ -1,3 +1,3 @@
 module Ruport
-  VERSION = "1.7.1"
+  VERSION = "1.8.0"
 end

--- a/ruport.gemspec
+++ b/ruport.gemspec
@@ -7,6 +7,10 @@ Gem::Specification.new do |s|
   s.name = %q{ruport}
 
   s.homepage = %q{http://github.com/ruport/ruport}
+  s.metadata = {
+    "source_code_uri" => "https://github.com/ruport/ruport",
+    "changelog_uri"   => "https://github.com/ruport/ruport/blob/master/CHANGELOG.md"
+  }
 
   s.version = Ruport::VERSION
 


### PR DESCRIPTION
- Markdown formatter #54
- Ruby 3.0 support

- Reduced allocations to improve performance #34
- Update Prawn version to 2.4.0 #44 #57 #64